### PR TITLE
chore: ampliar .gitignore para artefatos locais

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,23 @@ server.out.log
 server.err.log
 .env
 
+# Logs and temp files
+*.log
+*.tmp
+*.cache
+
+# PHP / Composer
+vendor/
+composer.lock
+
+# Node / frontend tooling
+node_modules/
+dist/
+build/
+
+# IDE / Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+


### PR DESCRIPTION
## Resumo
- Amplia o `.gitignore` com regras para logs e arquivos temporarios
- Ignora pastas comuns de IDE/editor
- Adiciona entradas de dependencias locais para evitar commits acidentais

Closes #4